### PR TITLE
reuse the identifier correctly

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,4 @@ https://github.com/cliqz-oss/langid_go/blob/master/langid_go.go#L3
 1. Loading your own model is not supported.
 2. No interface to get the probability values out.
 
-
 tags: golang, go, langid.go
-

--- a/langid_go.c
+++ b/langid_go.c
@@ -13,13 +13,11 @@ void destroy() {
 }
 
 const char *detect_language(char *text) {
-  LanguageIdentifier *idfr;
   int text_len;
   const char *lang;
 
   text_len = strlen(text);
 
-  idfr = get_default_identifier();
   lang = identify(idfr, text, text_len);
 
   return lang;


### PR DESCRIPTION
fixes a memory leak